### PR TITLE
Fixed an issue with probuf not working on macOS 12.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ If on Windows, you can use the [Windows Subsystem for Linux](https://en.wikipedi
 
 1. Clone this repo somewhere on your computer (ex: `git clone https://github.com/NicolasWebDev/reinstall-magisk-on-lineageos`)
 2. Edit the script to set both variables at the beginning of the program.
+3. Install android platform tools (https://developer.android.com/studio/releases/platform-tools). For Mac, use homebrew (https://formulae.brew.sh/cask/android-platform-tools) which will set the correct environment variables for you.
 
 ## Usage
 

--- a/reinstall-magisk-on-lineageos
+++ b/reinstall-magisk-on-lineageos
@@ -143,6 +143,7 @@ extract_boot_image_from_payload_file() {
     # For cases in which the repo has already been cloned, I prefer to create a random directory name to clone into, instead of deleting any file or directory on the user's machine.
     scripts_directory_name="scripts_$(generate_random_alnum_string_of_length_6)"
     git clone https://github.com/LineageOS/scripts /tmp/"$scripts_directory_name"
+    export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
     python3 /tmp/"$scripts_directory_name"/update-payload-extractor/extract.py --partitions boot --output_dir /tmp/ /tmp/payload.bin
 }
 


### PR DESCRIPTION
On macOS 12.6.

The function extract_boot_image_from_payload_file fails on the last line:
```
Cloning into '/tmp/scripts_yRmtKK'...
remote: Enumerating objects: 659, done.
remote: Counting objects: 100% (237/237), done.
remote: Compressing objects: 100% (114/114), done.
remote: Total 659 (delta 178), reused 156 (delta 110), pack-reused 422
Receiving objects: 100% (659/659), 222.40 KiB | 2.27 MiB/s, done.
Resolving deltas: 100% (332/332), done.
zsh: command not found: #export
Traceback (most recent call last):
  File "/tmp/scripts_yRmtKK/update-payload-extractor/extract.py", line 7, in <module>
    import update_payload
  File "/private/tmp/scripts_yRmtKK/update-payload-extractor/update_payload/__init__.py", line 22, in <module>
    from update_payload.checker import CHECKS_TO_DISABLE
  File "/private/tmp/scripts_yRmtKK/update-payload-extractor/update_payload/checker.py", line 40, in <module>
    from update_payload import common
  File "/private/tmp/scripts_yRmtKK/update-payload-extractor/update_payload/common.py", line 24, in <module>
    from update_payload import update_metadata_pb2
  File "/private/tmp/scripts_yRmtKK/update-payload-extractor/update_payload/update_metadata_pb2.py", line 32, in <module>
    _descriptor.EnumValueDescriptor(
  File "/opt/homebrew/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates

```

As it specifies, adding the environment variable allows the script to continue successfully, I did not notice any meaningful performance hit (it completed instantly).
I don't know how widespread this issue is, but if it works on Linux, consider adding this line or adding extra checks.
